### PR TITLE
Feat/26 delete old indexes

### DIFF
--- a/src/main/java/bio/overture/rollcall/config/RollcallConfig.java
+++ b/src/main/java/bio/overture/rollcall/config/RollcallConfig.java
@@ -19,6 +19,7 @@
 package bio.overture.rollcall.config;
 
 import lombok.*;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
@@ -48,18 +49,12 @@ public class RollcallConfig {
   @Data
   @NoArgsConstructor
   @AllArgsConstructor
+  @RequiredArgsConstructor
   public static class ConfiguredAlias {
-    private String alias;
-    private String entity;
-    private String type;
-    private int numOfRecentIndicesToKeepBesidesReleased;
-
-    public ConfiguredAlias(String alias, String entity, String type) {
-      this.alias = alias;
-      this.entity = entity;
-      this.type = type;
-      this.numOfRecentIndicesToKeepBesidesReleased = -1;
-    }
+    @NonNull private String alias;
+    @NonNull private String entity;
+    @NonNull private String type;
+    private int recentShardsToKeepOnRelease = -1;
   }
 
 }

--- a/src/main/java/bio/overture/rollcall/config/RollcallConfig.java
+++ b/src/main/java/bio/overture/rollcall/config/RollcallConfig.java
@@ -56,7 +56,7 @@ public class RollcallConfig {
     @NonNull private String alias;
     @NonNull private String entity;
     @NonNull private String type;
-    private int recentShardsToKeepOnRelease = -1;
+    private int releaseRotation = -1;
   }
 
 }

--- a/src/main/java/bio/overture/rollcall/config/RollcallConfig.java
+++ b/src/main/java/bio/overture/rollcall/config/RollcallConfig.java
@@ -18,10 +18,7 @@
 
 package bio.overture.rollcall.config;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
+import lombok.*;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
@@ -55,13 +52,13 @@ public class RollcallConfig {
     private String alias;
     private String entity;
     private String type;
-    private Optional<Integer> latestNonreleasedShardsToKeepOnRelease;
+    private int numOfRecentIndicesToKeepBesidesReleased;
 
     public ConfiguredAlias(String alias, String entity, String type) {
       this.alias = alias;
       this.entity = entity;
       this.type = type;
-      this.latestNonreleasedShardsToKeepOnRelease = Optional.empty();
+      this.numOfRecentIndicesToKeepBesidesReleased = -1;
     }
   }
 

--- a/src/main/java/bio/overture/rollcall/config/RollcallConfig.java
+++ b/src/main/java/bio/overture/rollcall/config/RollcallConfig.java
@@ -26,6 +26,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.List;
+import java.util.Optional;
 
 @Configuration
 @ConfigurationProperties("rollcall")
@@ -54,6 +55,14 @@ public class RollcallConfig {
     private String alias;
     private String entity;
     private String type;
+    private Optional<Integer> latestNonreleasedShardsToKeepOnRelease;
+
+    public ConfiguredAlias(String alias, String entity, String type) {
+      this.alias = alias;
+      this.entity = entity;
+      this.type = type;
+      this.latestNonreleasedShardsToKeepOnRelease = Optional.empty();
+    }
   }
 
 }

--- a/src/main/java/bio/overture/rollcall/config/RollcallConfig.java
+++ b/src/main/java/bio/overture/rollcall/config/RollcallConfig.java
@@ -18,13 +18,15 @@
 
 package bio.overture.rollcall.config;
 
-import lombok.*;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.List;
-import java.util.Optional;
 
 @Configuration
 @ConfigurationProperties("rollcall")

--- a/src/main/java/bio/overture/rollcall/repository/IndexRepository.java
+++ b/src/main/java/bio/overture/rollcall/repository/IndexRepository.java
@@ -18,7 +18,6 @@
 
 package bio.overture.rollcall.repository;
 
-import lombok.Data;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.val;
@@ -146,7 +145,7 @@ public class IndexRepository {
   }
 
   @SneakyThrows
-  public Map<String, Date> getIndexMappedToCreationDate(String... indices) {
+  public Map<String, Date> getIndicesMappedToCreationDate(String... indices) {
     val response = client.indices().get(new GetIndexRequest(indices).indicesOptions(IndicesOptions.lenientExpand()), RequestOptions.DEFAULT);
 
     val indicesSettings = response.getSettings();

--- a/src/main/java/bio/overture/rollcall/service/AliasService.java
+++ b/src/main/java/bio/overture/rollcall/service/AliasService.java
@@ -174,7 +174,7 @@ public class AliasService {
   }
 
   private List<String> getIndicesToDelete(AliasCandidates candidates, List<Shard> shards, List<String> releaseIndicesToIgnore) {
-    val numOfRecentIndicesToKeep = candidates.getAlias().getRecentShardsToKeepOnRelease();
+    val numOfRecentIndicesToKeep = candidates.getAlias().getReleaseRotation();
     if ( numOfRecentIndicesToKeep < 0) {
       return Collections.emptyList();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ rollcall:
       alias: file_centric
       entity: file
       type: centric
-      recentShardsToKeepOnRelease: 3
+      releaseRotation: 3
     -
       alias: participant_centric
       entity: participant

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ rollcall:
       alias: file_centric
       entity: file
       type: centric
-      latestNonreleasedShardsToKeepOnRelease: 3
+      numOfRecentIndicesToKeepBesidesReleased: 3
     -
       alias: participant_centric
       entity: participant

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,7 @@ rollcall:
       alias: file_centric
       entity: file
       type: centric
+      latestNonreleasedShardsToKeepOnRelease: 3
     -
       alias: participant_centric
       entity: participant

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ rollcall:
       alias: file_centric
       entity: file
       type: centric
-      numOfRecentIndicesToKeepBesidesReleased: 3
+      recentShardsToKeepOnRelease: 3
     -
       alias: participant_centric
       entity: participant

--- a/src/test/java/bio/overture/rollcall/service/AliasServiceTest.java
+++ b/src/test/java/bio/overture/rollcall/service/AliasServiceTest.java
@@ -40,7 +40,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.net.InetAddress;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/src/test/java/bio/overture/rollcall/service/AliasServiceTest.java
+++ b/src/test/java/bio/overture/rollcall/service/AliasServiceTest.java
@@ -90,7 +90,7 @@ public class AliasServiceTest {
   @Test
   public void getConfiguredTest() {
     val configured = service.getConfigured();
-    assertThat(configured).hasSize(1);
+    assertThat(configured).hasSize(2);
   }
 
   @Test

--- a/src/test/java/bio/overture/rollcall/service/AliasServiceTest.java
+++ b/src/test/java/bio/overture/rollcall/service/AliasServiceTest.java
@@ -40,6 +40,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.net.InetAddress;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -68,7 +69,7 @@ public class AliasServiceTest {
     client = new RestHighLevelClient( RestClient.builder(new HttpHost(InetAddress.getByName(esContainer.getIpAddress()), 10200)));
     repository = new IndexRepository(client);
 
-    val config = new RollcallConfig(Lists.list(new RollcallConfig.ConfiguredAlias("file_centric", "file", "centric")));
+    val config = new RollcallConfig(Lists.list(new RollcallConfig.ConfiguredAlias("file_centric", "file", "centric", Optional.of(1))));
     service = new AliasService(config, repository);
 
     client.indices().create(new CreateIndexRequest(INDEX1), RequestOptions.DEFAULT);
@@ -80,10 +81,8 @@ public class AliasServiceTest {
   @After
   @SneakyThrows
   public void tearDown() {
-    client.indices().delete(new DeleteIndexRequest(INDEX1), RequestOptions.DEFAULT);
-    client.indices().delete(new DeleteIndexRequest(INDEX2), RequestOptions.DEFAULT);
-    client.indices().delete(new DeleteIndexRequest(INDEX3), RequestOptions.DEFAULT);
-    client.indices().delete(new DeleteIndexRequest("badindex"), RequestOptions.DEFAULT);
+    // delete all indices
+    client.indices().delete(new DeleteIndexRequest("*"), RequestOptions.DEFAULT);
   }
 
   @Test
@@ -125,4 +124,38 @@ public class AliasServiceTest {
     assertThat(state2.get(INDEX2).get(0).alias()).isEqualTo("file_centric");
   }
 
+  @Test
+  @SneakyThrows
+  public void testReleaseAndDeleteOldShards() {
+    // release foobar2
+    val request1 = new AliasRequest("file_centric", "RE_foobar2", Lists.list( "sd_preasa7s"));
+    service.release(request1);
+
+    // verify aliases assigned to indices
+    val state1 = repository.getAliasState();
+    assertThat(state1.get(INDEX1).isEmpty()).isTrue();
+    assertThat(state1.get(INDEX2).isEmpty()).isTrue();
+    assertThat(state1.get(INDEX3).get(0).alias()).isEqualTo("file_centric");
+
+    // add new index and assert current indices
+    final String INDEX4 = "file_centric_sd_preasa7s_re_foobar3";
+    client.indices().create(new CreateIndexRequest(INDEX4), RequestOptions.DEFAULT);
+    val indicesBeforeRelease = repository.getIndices();
+    assertThat(indicesBeforeRelease).containsExactlyInAnyOrder(INDEX1, INDEX2, INDEX3, "badindex", INDEX4);
+
+    // release foobar3
+    val request2 = new AliasRequest("file_centric", "RE_foobar3", Lists.list("SD_preasa7s"));
+    service.release(request2);
+
+    // verify aliases assigned to indices
+    val state2 = repository.getAliasState();
+    assertThat(state2.get(INDEX1).isEmpty()).isTrue();
+    assertThat(state2.get(INDEX2)).isNull(); // deleted old index, keeping latest 1 NonReleastedShard
+    assertThat(state2.get(INDEX3).isEmpty()).isTrue();
+    assertThat(state2.get(INDEX4).get(0).alias()).isEqualTo("file_centric");
+
+    // assert current indices
+    val indicesAfterRelease = repository.getIndices();
+    assertThat(indicesAfterRelease).containsExactlyInAnyOrder(INDEX1, INDEX3, "badindex", INDEX4);
+  }
 }

--- a/src/test/java/bio/overture/rollcall/service/AliasServiceTest.java
+++ b/src/test/java/bio/overture/rollcall/service/AliasServiceTest.java
@@ -66,7 +66,7 @@ public class AliasServiceTest {
   @Before
   @SneakyThrows
   public void setUp() {
-    client = new RestHighLevelClient( RestClient.builder(new HttpHost(InetAddress.getByName(esContainer.getIpAddress()), 10200)));
+    client = new RestHighLevelClient( RestClient.builder(new HttpHost(InetAddress.getByName(esContainer.getContainerIpAddress()), 10200)));
     repository = new IndexRepository(client);
 
     val config = new RollcallConfig(Lists.list(new RollcallConfig.ConfiguredAlias("file_centric", "file", "centric", 1)));


### PR DESCRIPTION
Proposed changes:
- Added a delete indicies step to the release prcoess, which removes oldest indices based on a config var
- Added new env variable `recentShardsToKeepOnRelease` to configure how many indices are kept in es besides the released one
- Added test for feat